### PR TITLE
Open generic ModList screen instead of your config GUI.

### DIFF
--- a/src/main/java/com/tierzero/stacksonstacks/PileHandler.java
+++ b/src/main/java/com/tierzero/stacksonstacks/PileHandler.java
@@ -138,10 +138,4 @@ public class PileHandler {
 		}
 		return new int[] { x1, y1, z1 };
 	}
-
-	@SideOnly(Side.CLIENT)
-	@SubscribeEvent(priority = EventPriority.NORMAL, receiveCanceled = true)
-	public void onEvent(GuiOpenEvent event) {
-	}
-
 }

--- a/src/main/java/com/tierzero/stacksonstacks/PileHandler.java
+++ b/src/main/java/com/tierzero/stacksonstacks/PileHandler.java
@@ -138,4 +138,12 @@ public class PileHandler {
 		}
 		return new int[] { x1, y1, z1 };
 	}
+	
+	@SideOnly(Side.CLIENT)
+	@SubscribeEvent(priority=EventPriority.NORMAL, receiveCanceled=true)
+	public void onEvent(GuiOpenEvent event) {
+		if (event.gui instanceof GuiIngameModOptions) {
+			event.gui = new GuiModList(new GuiIngameMenu());
+		}
+	}
 }


### PR DESCRIPTION
Don't open your ConfigGUI when Mod Options is clicked Instead open the ModList GUI so all mods can be configured.  Doing it your way disables all other mods being able to have configurable options in game without having to quit the world.  References #36 