### PR TITLE
Fix for bonemeal exploit

### DIFF
--- a/src/main/java/com/tierzero/stacksonstacks/PileHandler.java
+++ b/src/main/java/com/tierzero/stacksonstacks/PileHandler.java
@@ -65,6 +65,11 @@ public class PileHandler {
 						if (heldItemStack.getItem().equals(Items.redstone) && blockAtPlacementPosition != Blocks.redstone_wire) {
 							return;
 						}
+						
+						//Prevent placing bonemeal on grass to avoid getting free plants/long grass.
+						if (heldItemStack.getItem().equals(Items.dye) && heldItemStack.getItemDamage() == 15 && blockAtPlacementPosition.equals(Blocks.grass) {
+							return;
+						}
 
 						event.world.setBlock(placementX, placementY, placementZ, SoS.blockPile);
 						event.world.getBlock(placementX, placementY, placementZ).onBlockPlacedBy(event.world,


### PR DESCRIPTION
Placing bone meal on grass grows long grass & plants without taking away the bone meal, as it's placed on the floor instead. This is just a quick fix, if you want a proper fix you need to cancel the event if they're sneaking and then only place the stack while sneaking, or something like that.

(Not tested, did this directly on GitHub. Should work fine though.)